### PR TITLE
fix: Complatible test settings for Django 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__
 # Emacs
 *~
 
+# IDEA
+.idea
+
 # Virtual env
 /env
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,13 +19,12 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -66,13 +65,6 @@ TEMPLATES = [
             ],
         },
     },
-]
-
-
-MIDDLEWARE_CLASSES = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
 ]
 
 ADYEN_HOST_URL = 'http://localhost:8000'

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -136,6 +136,11 @@ class ConfirmationView(AdyenSigMixin, WebTest):
             'merchantReference': self.order.reference
         }
 
+    def _get_csrf_token(self):
+        url = reverse('redirect', kwargs={'reference': self.order.reference})
+        response = self.app.get(url)
+        return response.forms[0]['csrfmiddlewaretoken'].value
+
     def test_empty_get(self):
         with self.assertRaises(AppError):
             self.app.get(self.url)
@@ -193,6 +198,7 @@ class ConfirmationView(AdyenSigMixin, WebTest):
     def test_post(self):
         self.params['authResult'] = 'AUTHORISED'
         params = self.sign_params(self.params)
+        params['csrfmiddlewaretoken'] = self._get_csrf_token()
         response = self.app.post(self.url, params=params)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, '\n    Success!\n\n')
@@ -200,6 +206,7 @@ class ConfirmationView(AdyenSigMixin, WebTest):
     def test_psp_reference(self):
         self.params['pspReference'] = 'reference'
         params = self.sign_params(self.params)
+        params['csrfmiddlewaretoken'] = self._get_csrf_token()
         response = self.app.post(self.url, params=params)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, '\n    Success!\n\n')


### PR DESCRIPTION
Support for old-style middleware using settings.MIDDLEWARE_CLASSES is removed
in Django version 2.0

https://docs.djangoproject.com/en/2.0/releases/2.0/